### PR TITLE
OUT-2373 | Mark invoice / product / price sync failure in DB

### DIFF
--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -1,4 +1,6 @@
 import { handleCopilotWebhook } from '@webhook/api/webhook.controller'
 import { withErrorHandler } from '@/utils/withErrorHandler'
 
+export const maxDuration = 300
+
 export const POST = withErrorHandler(handleCopilotWebhook)

--- a/src/db/migrations/20250923102716_add_failed_syncs_table.sql
+++ b/src/db/migrations/20250923102716_add_failed_syncs_table.sql
@@ -1,0 +1,15 @@
+CREATE TYPE "public"."failed_syncs_type" AS ENUM('invoice.created', 'product.updated', 'price.created');
+CREATE TABLE "failed_syncs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"portal_id" varchar(16) NOT NULL,
+	"type" "failed_syncs_type" NOT NULL,
+	"token" varchar(1024) NOT NULL,
+	"resource_id" varchar(64) NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"payload" jsonb NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX "uq_failed_syncs_resource_id" ON "failed_syncs" USING btree ("resource_id");

--- a/src/db/migrations/meta/20250923102716_snapshot.json
+++ b/src/db/migrations/meta/20250923102716_snapshot.json
@@ -1,0 +1,465 @@
+{
+  "id": "4dbe7d90-9d31-4a06-b63a-d98974d6fb55",
+  "prevId": "39b63cf4-6258-4ca7-97dc-ecdefca400c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.failed_syncs": {
+      "name": "failed_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "failed_syncs_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_failed_syncs_resource_id": {
+          "name": "uq_failed_syncs_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_contacts": {
+      "name": "synced_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_contacts_portal_id_client_id": {
+          "name": "uq_synced_contacts_portal_id_client_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_invoices": {
+      "name": "synced_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_invoice_id": {
+          "name": "copilot_invoice_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xero_invoice_id": {
+          "name": "xero_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "synced_invoices_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_invoices_portal_id_copilot_invoice_id": {
+          "name": "uq_synced_invoices_portal_id_copilot_invoice_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "copilot_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_items": {
+      "name": "synced_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_items_portal_id_product_id_price_id": {
+          "name": "uq_synced_items_portal_id_product_id_price_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xero_connections": {
+      "name": "xero_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_set": {
+          "name": "token_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_xero_connections_portal_id": {
+          "name": "uq_xero_connections_portal_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.failed_syncs_type": {
+      "name": "failed_syncs_type",
+      "schema": "public",
+      "values": ["invoice.created", "product.updated", "price.created"]
+    },
+    "public.synced_invoices_status": {
+      "name": "synced_invoices_status",
+      "schema": "public",
+      "values": ["pending", "failed", "success"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1758254954871,
       "tag": "20250919040914_add_inital_sync_tables",
       "breakpoints": false
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1758623236059,
+      "tag": "20250923102716_add_failed_syncs_table",
+      "breakpoints": false
     }
   ]
 }

--- a/src/db/schema/failedSyncs.schema.ts
+++ b/src/db/schema/failedSyncs.schema.ts
@@ -1,0 +1,42 @@
+import { integer, jsonb, pgEnum, pgTable, uniqueIndex, uuid, varchar } from 'drizzle-orm/pg-core'
+import { timestamps } from '@/db/db.helpers'
+import { ValidWebhookEvent } from '@/features/invoice-sync/types'
+
+export const failedSyncTypeEnum = pgEnum('failed_syncs_type', [
+  ValidWebhookEvent.InvoiceCreated,
+  ValidWebhookEvent.ProductUpdated,
+  ValidWebhookEvent.PriceCreated,
+])
+
+export const failedSyncs = pgTable(
+  'failed_syncs',
+  {
+    id: uuid().primaryKey().notNull().defaultRandom(),
+
+    // Workspace ID / Portal ID in Copilot
+    portalId: varchar({ length: 16 }).notNull(),
+
+    // Type of sync
+    type: failedSyncTypeEnum().notNull(),
+
+    // Token used for sync
+    token: varchar({ length: 1024 }).notNull(),
+
+    // ID of the resource (price / invoice)
+    resourceId: varchar({ length: 64 }).notNull(),
+
+    // Number of attempts to sync item
+    attempts: integer().notNull().default(0),
+
+    // Payload of the failed sync webhook
+    payload: jsonb().notNull(),
+
+    // Active Tenant ID (most recently connected Xero organization)
+    tenantId: uuid().notNull(),
+
+    ...timestamps,
+  },
+
+  // Only allow one failed sync record per failed resource
+  (t) => [uniqueIndex('uq_failed_syncs_resource_id').on(t.resourceId)],
+)

--- a/src/features/failed-sync-handling/lib/FailedSyncs.service.ts
+++ b/src/features/failed-sync-handling/lib/FailedSyncs.service.ts
@@ -1,0 +1,55 @@
+import { and, eq } from 'drizzle-orm'
+import db from '@/db'
+import { failedSyncs } from '@/db/schema/failedSyncs.schema'
+import type { ValidWebhookEvent } from '@/features/invoice-sync/types'
+import BaseService from '@/lib/copilot/services/base.service'
+
+class FailedSyncsService extends BaseService {
+  async addFailedSyncRecord(
+    tenantId: string,
+    type: ValidWebhookEvent,
+    payload: object & { id: string },
+  ): Promise<void> {
+    const [existingFailedSync] = await db
+      .select()
+      .from(failedSyncs)
+      .where(
+        and(
+          eq(failedSyncs.portalId, this.user.portalId),
+          eq(failedSyncs.tenantId, tenantId),
+          eq(failedSyncs.resourceId, payload.id),
+        ),
+      )
+    if (existingFailedSync) {
+      await db
+        .update(failedSyncs)
+        .set({
+          attempts: existingFailedSync.attempts + 1,
+        })
+        .where(eq(failedSyncs.id, existingFailedSync.id))
+    } else {
+      await db.insert(failedSyncs).values({
+        portalId: this.user.portalId,
+        tenantId,
+        resourceId: payload.id,
+        type,
+        payload,
+        token: this.user.token,
+      })
+    }
+  }
+
+  async deleteFailedSync(portalId: string, tenantId: string, recordId: string) {
+    await db
+      .delete(failedSyncs)
+      .where(
+        and(
+          eq(failedSyncs.portalId, portalId),
+          eq(failedSyncs.tenantId, tenantId),
+          eq(failedSyncs.resourceId, recordId),
+        ),
+      )
+  }
+}
+
+export default FailedSyncsService


### PR DESCRIPTION
## Changes

- [x] Add `failed_syncs` table + schema
- [x] Wrap webhook handler in try... catch to add new record to failed_syncs on failure

## NOTE:

This PR doesn't handle retrying failed syncs, which is scheduled for a later milestone

## Testing Criteria

- [x] Screencast


https://github.com/user-attachments/assets/a4ec128a-80a2-45be-a668-4fd42cdc65be

